### PR TITLE
fix: Default PKG Version to None

### DIFF
--- a/uv_lock_report/models.py
+++ b/uv_lock_report/models.py
@@ -52,7 +52,7 @@ class LockfilePackage(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     name: str
-    version: Version | str | None
+    version: Version | str | None = None
 
     def __str__(self) -> str:
         return f"{self.name}: {self.version}"


### PR DESCRIPTION
## Description

This change ensures we automagically use `None` if no version exists in the lockfile.