### PR TITLE
fix: Properly Escape Simple Output

### DIFF
--- a/uv_lock_report/models.py
+++ b/uv_lock_report/models.py
@@ -204,12 +204,14 @@ class LockfileChanges(BaseModel):
         all = ["# uv Lockfile Report"]
         if self.added:
             all.append("## Added Packages")
-            all.extend([f"`{added.name}`: `{added.version}`" for added in self.added])
+            all.extend(
+                [f"\\`{added.name}\\`: \\`{added.version}\\`" for added in self.added]
+            )
         if self.updated:
             all.append("## Changed Packages")
             all.extend(
                 [
-                    f"`{updated.name}`: `{updated.old_version}` -> `{updated.new_version}`"
+                    f"\\`{updated.name}\\`: \\`{updated.old_version}\\` -> \\`{updated.new_version}\\`"
                     for updated in self.updated
                 ]
             )
@@ -217,7 +219,10 @@ class LockfileChanges(BaseModel):
         if self.removed:
             all.append("## Removed Packages")
             all.extend(
-                [f"`{removed.name}`: `{removed.version}`" for removed in self.removed]
+                [
+                    f"\\`{removed.name}\\`: \\`{removed.version}\\`"
+                    for removed in self.removed
+                ]
             )
         return "\n".join(all)
 

--- a/uv_lock_report/tests/conftest.py
+++ b/uv_lock_report/tests/conftest.py
@@ -41,14 +41,14 @@ EXPECTED_LOCKFILE_CHANGES_FULL_TABLE = """
 EXPECTED_LOCKFILE_CHANGES_FULL_SIMPLE = """
 # uv Lockfile Report
 ## Added Packages
-`added_1`: `1.0.0`
-`added_2`: `4.2.0`
+\\`added_1\\`: \\`1.0.0\\`
+\\`added_2\\`: \\`4.2.0\\`
 ## Changed Packages
-`updated_1`: `1.0.0` -> `2.0.0`
-`updated_2`: `1.0.0` -> `2.0.0`
+\\`updated_1\\`: \\`1.0.0\\` -> \\`2.0.0\\`
+\\`updated_2\\`: \\`1.0.0\\` -> \\`2.0.0\\`
 ## Removed Packages
-`removed_1`: `1.0.0`
-`removed_2`: `4.2.0`
+\\`removed_1\\`: \\`1.0.0\\`
+\\`removed_2\\`: \\`4.2.0\\`
 """.strip()
 
 


### PR DESCRIPTION
## Description

This change properly escapes the backticks in the simple output format.