### PR TITLE
Fix Hatch Build Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+report.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "0.0.1"
 
 [tool.hatch.metadata.hooks.vcs.urls]
 Homepage = "https://github.com/mw-root/uv-lock-report"


### PR DESCRIPTION
This fixes the issue with building editable versions without a full git clone by adding a fallback version.

It's probably not the best solution, but it fixes this for now.