### PR TITLE
chore: Remove Setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,22 +9,20 @@ dynamic = ["version", "urls"]
 [project.scripts]
 uv-lock-report = "uv_lock_report.cli:main"
 
-
 [tool.ruff]
 
 [tool.ty.src]
 exclude = [
-    # Ty doesn't seem to understand populating pydantic models by name.
-    "uv_lock_report/tests/test_lock_file_reporter.py",
-    "uv_lock_report/tests/test_updated_package.py",
-    "uv_lock_report/tests/test_lockfile.py",
-    "uv_lock_report/tests/conftest.py",
+  # Ty doesn't seem to understand populating pydantic models by name.
+  "uv_lock_report/tests/test_lock_file_reporter.py",
+  "uv_lock_report/tests/test_updated_package.py",
+  "uv_lock_report/tests/test_lockfile.py",
+  "uv_lock_report/tests/conftest.py",
 ]
 
 [dependency-groups]
 dev = [{ include-group = "test" }]
 test = ["pytest>=8.4.2", "pytest-cov>=7.0.0"]
-
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,6 @@ requires-python = ">=3.13"
 dependencies = ["packaging>=25.0", "pydantic>=2.11.9"]
 dynamic = ["version", "urls"]
 
-[tool.setuptools.packages.find]
-where = ["uv_lock_report"]
-
 [project.scripts]
 uv-lock-report = "uv_lock_report.cli:main"
 


### PR DESCRIPTION
## Description

This change removes setuptools. It should not have been configured in the first place. 

We are using hatch as our build backend.