### PR TITLE
chore: ignore packages newer than 1 week

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version", "urls"]
 [project.scripts]
 uv-lock-report = "uv_lock_report.cli:main"
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.ruff]
 
 [tool.ty.src]


### PR DESCRIPTION
This change tells our package manager (uv) to ignore any packages newer than 1 week. 
This is in part to ensure Renovate isn't proposing brand new packages due to the rise in supply chain attacks against popular libraries.