### PR TITLE
chore: Disable Updates for this Action

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,15 @@
         "pinDigest"
       ],
       "enabled": true
-    }
+    },
+    {
+        "matchManagers": [
+            "github-actions"
+        ],
+        "matchPackageNames": [
+            "mw-root/uv-lock-report"
+        ],
+        "enabled": false
+        }
   ]
 }


### PR DESCRIPTION
This change should disable digest pinning and updates to itself in.. itself?

We always want to use the main branch. I won't want to keep merging changes in a never-ending cycle to make sure we're using the latest pin or pin of released version.