### PR TITLE
Wait 1 week for Action Releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,12 @@
   },
   "packageRules": [
     {
+      "minimumReleaseAge": "7 days",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
       "description": "Group all GitHub Actions updates into a single PR",
       "groupName": "Minor and patch GitHub Actions updates",
       "matchManagers": [
@@ -59,6 +65,6 @@
             "mw-root/uv-lock-report"
         ],
         "enabled": false
-        }
+    }
   ]
 }


### PR DESCRIPTION
This change will delay renovate proposing action updates by 1 week.

This is intended to increase stability as well as provide some protection from supply chain attacks.